### PR TITLE
Feature: 添加Skill组件，用于显示单个/多个技能名

### DIFF
--- a/src/components/typography/Skill.astro
+++ b/src/components/typography/Skill.astro
@@ -1,0 +1,57 @@
+---
+/*
+
+Skill.astro
+Author: Fish Fly
+
+Use to show skills' name when boss cast randomly from multiple options
+
+Param:
+  - name              : string/array of skills' name
+  - variant?          : variant of the internal <Span> elements
+  - separatorVariant? : variant of the saparators
+  - slot separator    : replace the default separator '|'
+
+Example:  <Skill
+              skill={['crychic', 'mygo', 'avemujica']}
+              isHeader={true}
+          >
+              <Span slot="separator" variant="lime">&</span>    // uses custom separator
+          </Skill>
+
+*/
+
+import type { VariantType } from '@/lib/variant'
+
+import Span from '@/components/Span.vue'
+
+interface Props {
+  name: string | string[]
+  variant?: VariantType
+  separatorVariant?: VariantType
+}
+
+const { name = '', variant = 'yellow', separatorVariant = 'fuchsia' } = Astro.props
+---
+
+<!-- class skill-name may be used for future's identification  -->
+<div class={`skill-name align-middle`}>
+  {
+    !Array.isArray(name) ? (
+      // if name is a string
+      <Span variant={variant}>{name}</Span>
+    ) : (
+      // or an Array
+      name.map((item, index) => (
+        <>
+          <Span variant={variant}>{item}</Span>
+          {index < name.length - 1 && (
+            <slot name="separator">
+              <Span variant={separatorVariant}>|</Span>
+            </slot>
+          )}
+        </>
+      ))
+    )
+  }
+</div>


### PR DESCRIPTION
rt
用法写在注释里了
留了一个skill-name的class用来（也许会有用）筛选用？
不需要的话可以去掉