### PR TITLE
Fix: 简洁模式下Buff字体样式

### DIFF
--- a/src/components/Buff.vue
+++ b/src/components/Buff.vue
@@ -14,7 +14,10 @@ const props = defineProps<{
 </script>
 
 <template>
-  <span :class="cn('relative -mx-[calc(1em*2/18)] inline-block h-[calc(1em*27/18)] w-[calc(1em*27/18)]', props.class)">
+  <span
+    :class="cn('relative -mx-[calc(1em*2/18)] inline-block h-[calc(1em*27/18)] w-[calc(1em*27/18)]', props.class)"
+    data-icon="buff-icon"
+  >
     <div class="relative inline-block w-full translate-y-[-12.5%] align-middle">
       <slot>
         <img :src="icon.src" :alt="description">
@@ -23,6 +26,7 @@ const props = defineProps<{
     <span
       v-if="tag"
       class="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-3/5 text-[calc(1em*12/18)] whitespace-nowrap text-white [text-shadow:_0_0_2px_black,_0_0_2px_black,_0_0_2px_black,_0_0_3px_black,_0_0_3px_black,_0_0_3px_black]"
+      data-icon="buff-icon"
     >
       {{ tag }}
     </span>

--- a/src/layouts/DutyStratLayout.astro
+++ b/src/layouts/DutyStratLayout.astro
@@ -85,17 +85,13 @@ const duty = (await getEntry('duties', dutyId))!.data
     }
     // 对于阅读模式
     const highlightTextQuery =
-      'section.strat-section:not(.separator-section) span:not(.strat-time):not(.damage-info):not(.strat-title)'
+      'section.strat-section:not(.separator-section) span:not(.strat-time):not(.damage-info):not(.strat-title):not([data-icon="buff-icon"])'
     if (stratSettings.readMode === 'minimal') {
       const colorClassReg = /^text-[a-z]+-\d{3}(?:\/\d+)?$/
       const darkColorClassReg = /^dark:text-[a-z]+-\d{3}(?:\/\d+)?$/
       const textShadowReg = /^\[text-shadow.*\]$/
       // 对于高亮词条
       document.querySelectorAll<HTMLElement>(highlightTextQuery).forEach((e) => {
-        // 跳过buff等vue组件
-        // if (e.closest('astro-island')) {
-        //   return
-        // }
         if (!e.dataset.originalClass) {
           e.dataset.originalClass = e.className
         }


### PR DESCRIPTION
目前简洁模式下会修改Buff图标文本字体阴影样式，在浅色模式下阅读体验差。
通过在Buff.vue内添加`data-icon="buff-icon"`，标识Buff相关组件，将Buff文本排除在简洁模式修改样式的范围之外。