### PR TITLE
Feature: m7s, m8s及zelenia部分图标适配简洁模式

### DIFF
--- a/src/components/RoleIcon.astro
+++ b/src/components/RoleIcon.astro
@@ -25,7 +25,7 @@ interface Props {
 
 const tagHandler = (tag: string): string => {
   // 添加文本使攻略行文通顺
-  if (['最近', '最远'].includes(tag)) return `${tag}目标`
+  if (['最近', '最远', '非T', '随机'].includes(tag)) return `${tag}目标`
   else return tag
 }
 

--- a/src/components/RoleIcon.astro
+++ b/src/components/RoleIcon.astro
@@ -25,7 +25,7 @@ interface Props {
 
 const tagHandler = (tag: string): string => {
   // 添加文本使攻略行文通顺
-  if (['最近', '最远', '非T', '随机'].includes(tag)) return `${tag}目标`
+  if (['最近', '最远', '随机'].includes(tag)) return `${tag}目标`
   else return tag
 }
 

--- a/src/pages/07/m7s/_components/AbBlinkCast.astro
+++ b/src/pages/07/m7s/_components/AbBlinkCast.astro
@@ -20,8 +20,8 @@ const abominableBlink = translations.abominableBlink
 
 <CastSection start={start} base={base} duration={5.0} ability={abominableBlink}>
   <BruteAbombinator slot="source" />
-  对
-  <RoleIcon role="tank" tag="其一" />
+  对任一
+  <RoleIcon role="tank" />
   施加距离衰减AoE点名
   <DamageInfo damage="70000~160000" type="magical" />
   <Badge variant="pink">AoE</Badge>

--- a/src/pages/07/m7s/_components/BloomingAbomination.astro
+++ b/src/pages/07/m7s/_components/BloomingAbomination.astro
@@ -1,5 +1,6 @@
 ---
 import EntityIcon from '@/components/EntityIcon.astro'
+import EntityText from '@/components/EntityText.astro'
 import Span from '@/components/Span.vue'
 
 import bloomingAbominationIcon from '@/assets/07/m7s/entity_icons/blooming_abomination.png'
@@ -18,3 +19,4 @@ const bloomingAbomination = translations.bloomingAbomination
   <Span variant="rose" class="ml-1">{bloomingAbomination}</Span>
   <Span variant="rose">×{num}</Span>
 </EntityIcon>
+<EntityText>{bloomingAbomination}×{num}</EntityText>

--- a/src/pages/07/m7s/_components/BloomingAbominationSimplified.astro
+++ b/src/pages/07/m7s/_components/BloomingAbominationSimplified.astro
@@ -1,5 +1,6 @@
 ---
 import EntityIcon from '@/components/EntityIcon.astro'
+import EntityText from '@/components/EntityText.astro'
 
 import Span from '@/components/Span.vue'
 
@@ -12,3 +13,4 @@ const bloomingAbomination = translations.bloomingAbomination
 <EntityIcon icon={bloomingAbominationIcon} alt="BOSS" iconClass="scale-125 drop-shadow-xs drop-shadow-black">
   <Span variant="rose" class="ml-1">{bloomingAbomination}</Span>
 </EntityIcon>
+<EntityText>{bloomingAbomination}</EntityText>

--- a/src/pages/07/m7s/_components/BruteAbombinator.astro
+++ b/src/pages/07/m7s/_components/BruteAbombinator.astro
@@ -1,7 +1,9 @@
 ---
 import EntityIcon from '@/components/EntityIcon.astro'
+import EntityText from '@/components/EntityText.astro'
 
 import boss from '@/assets/07/m7s/entity_icons/boss.png'
 ---
 
 <EntityIcon icon={boss} alt="BOSS" iconClass="scale-125 drop-shadow-xs drop-shadow-black" />
+<EntityText>BOSS</EntityText>

--- a/src/pages/07/m7s/_mechanics/DDAB.astro
+++ b/src/pages/07/m7s/_mechanics/DDAB.astro
@@ -50,8 +50,8 @@ const { start, base = 0 }: Props = Astro.props
     <div class="paragraph">
       同时，
       <Boss />
-      对
-      <RoleIcon role="tank" tag="其一" />
+      对任一
+      <RoleIcon role="tank" />
       点名
       <Span variant="pink">核爆</Span>
     </div>
@@ -61,12 +61,12 @@ const { start, base = 0 }: Props = Astro.props
   <div class="flex flex-col gap-4">
     <div class="paragraph">
       <RoleIcon role="dps" tag="D3" />
-      接短边的DoT线， D4<RoleIcon role="dps" tag="D4" />
+      接短边的DoT线， <RoleIcon role="dps" tag="D4" />
       接长边的DoT线
     </div>
     <div class="paragraph">
       被点名核爆的
-      <RoleIcon role="tank" tag="其一" />
+      <RoleIcon role="tank" />
       尽可能远离人群
     </div>
     <h4 class="mt-4 text-2xl">

--- a/src/pages/07/m7s/_mechanics/SinisterSeeds.astro
+++ b/src/pages/07/m7s/_mechanics/SinisterSeeds.astro
@@ -210,7 +210,7 @@ const bloomingAbomination = translations.bloomingAbomination
       <RoleIcon role="all" tag="一仇" />的普通攻击， 对<RoleIcon role="tank" />造成<DamageInfo
         damage="28000"
         type="physical"
-      />， 对<RoleIcon role="all" tag="非T" />造成<DamageInfo damage="45000" type="physical" />
+      />， 对<RoleIcon role="healer|dps" />造成<DamageInfo damage="45000" type="physical" />
     </div>
   </div>
   <div class="flex flex-col gap-4">

--- a/src/pages/07/m8s1/_components/StoneWolfheadIcon.astro
+++ b/src/pages/07/m8s1/_components/StoneWolfheadIcon.astro
@@ -1,7 +1,9 @@
 ---
 import EntityIcon from '@/components/EntityIcon.astro'
+import EntityText from '@/components/EntityText.astro'
 
 import StoneWolf from '@/assets/07/m8s1/entity_icons/wolf_of_stone_1.png'
 ---
 
 <EntityIcon icon={StoneWolf} alt="StoneWolfHead" iconClass="scale-125 drop-shadow-xs drop-shadow-black" />
+<EntityText>土狼首</EntityText>

--- a/src/pages/07/m8s1/_components/TrackingTremorsCast.astro
+++ b/src/pages/07/m8s1/_components/TrackingTremorsCast.astro
@@ -37,7 +37,7 @@ const damageApplyTime =
   duration={duration}
   ability={ability}
   target="any"
-  targetTag="1"
+  targetTag="1人"
   damage="800000"
   damageType="magical"
 >

--- a/src/pages/07/m8s1/_components/WindWolfheadIcon.astro
+++ b/src/pages/07/m8s1/_components/WindWolfheadIcon.astro
@@ -1,7 +1,9 @@
 ---
 import EntityIcon from '@/components/EntityIcon.astro'
+import EntityText from '@/components/EntityText.astro'
 
 import WindWolf from '@/assets/07/m8s1/entity_icons/wolf_of_wind_1.png'
 ---
 
 <EntityIcon icon={WindWolf} alt="WindDragonhead" iconClass="scale-120 drop-shadow-xs drop-shadow-black" />
+<EntityText>风狼首</EntityText>

--- a/src/pages/07/m8s2/_components/GleamingFang.astro
+++ b/src/pages/07/m8s2/_components/GleamingFang.astro
@@ -1,5 +1,6 @@
 ---
 import EntityIcon from '@/components/EntityIcon.astro'
+import EntityText from '@/components/EntityText.astro'
 import Span from '@/components/Span.vue'
 
 import gleaming_fang from '@/assets/07/m8s1/entity_icons/gleaming_fang.png'
@@ -8,3 +9,4 @@ import gleaming_fang from '@/assets/07/m8s1/entity_icons/gleaming_fang.png'
 <EntityIcon icon={gleaming_fang} alt="Gleaming Fang Icon" iconClass="scale-120 drop-shadow-xs drop-shadow-black">
   <Span variant="rose" class="ml-1">浮游炮</Span>
 </EntityIcon>
+<EntityText>浮游炮</EntityText>

--- a/src/pages/07/m8s2/_components/HowlingBlade.astro
+++ b/src/pages/07/m8s2/_components/HowlingBlade.astro
@@ -1,7 +1,9 @@
 ---
 import EntityIcon from '@/components/EntityIcon.astro'
+import EntityText from '@/components/EntityText.astro'
 
 import boss from '@/assets/07/m8s1/entity_icons/boss.png'
 ---
 
 <EntityIcon icon={boss} alt="Howling Blade Icon" iconClass="scale-125 drop-shadow-xs drop-shadow-black" />
+<EntityText>BOSS</EntityText>

--- a/src/pages/07/zelenia/_components/Zelenia.astro
+++ b/src/pages/07/zelenia/_components/Zelenia.astro
@@ -1,9 +1,9 @@
 ---
-import EntityIcon from '@/components/EntityIcon.astro'
+import EntityText from '@/components/EntityText.astro'
 
-import boss from '@/assets/07/m6s/entity_icons/boss.png'
 import RoleIcon from '@/components/RoleIcon.astro'
 ---
 
 <!-- <EntityIcon icon={boss} alt="BOSS" iconClass="drop-shadow-xs drop-shadow-black" /> -->
-<RoleIcon role="boss"/>
+<RoleIcon role="boss" />
+<EntityText>BOSS</EntityText>


### PR DESCRIPTION
1. 添加图标在简洁模式下的文本适配，包括
    1.  m7s的boss及小怪
    2.  m8s的boss、浮游炮和狼头
    3.  zelenia的boss图标
2. m7s内的部分文本针对简洁模式做了润色，包括
    1. RoleIcon内添加了对“非T”、“随机”两种图标文本的特殊处理，用于
https://github.com/mogworks/xivstrat/blob/c44b91e56c3a4485634a1c3968f35ead5e46e928/src/pages/07/m7s/_mechanics/SinisterSeeds.astro#L213
https://github.com/mogworks/xivstrat/blob/c44b91e56c3a4485634a1c3968f35ead5e46e928/src/pages/07/m8s2/_components/MooncleaverCast.astro#L24
    2. 其他一些文本润色