### PR TITLE
fix: 调整5~8层下载标点文件文案

### DIFF
--- a/src/components/WaymarkBox.astro
+++ b/src/components/WaymarkBox.astro
@@ -6,38 +6,44 @@ import Separator from '@/components/Separator.astro'
 import ResizableImageDialog from '@/components/ResizableImageDialog.vue'
 import T from '@/components/typography/T.astro'
 
+import { cn } from '@/lib/utils'
+
 interface Props {
-  href: string
+  href?: string
+  downloadLabel?: string
   img?: ImageMetadata
 }
 
-const { href, img }: Props = Astro.props
+const { href, img, downloadLabel = '下载标点文件' }: Props = Astro.props
 ---
 
 <div class="flex gap-6">
-  <div class="w-lg">
-    <AreaBox>
-      <waymark-download-button
-        href={href}
-        class="!disabled:hover:bg-purple-700/60 inline-flex w-max cursor-pointer items-center justify-between gap-1 rounded-lg border border-purple-400 bg-purple-500 p-1 px-2 align-middle text-xs text-white disabled:cursor-not-allowed disabled:opacity-50 dark:border-purple-500 dark:bg-purple-700/75"
-      >
-        下载标点文件
-      </waymark-download-button>
-      <slot>
-        {
-          img && (
-            <>
-              <Separator class="my-2 mb-3" />
-              <ResizableImageDialog client:idle>
-                <Image src={img} alt="场地标点" class="w-full object-contain object-left-top" />
-              </ResizableImageDialog>
-            </>
-          )
-        }
-      </slot>
-    </AreaBox>
-  </div>
-  <AreaBox>
+  <AreaBox class="w-lg">
+    <waymark-download-button
+      href={href}
+      disabled={!href}
+      class={cn(
+        'inline-flex w-max cursor-pointer items-center justify-between gap-1 rounded-lg border border-purple-400 bg-purple-500 p-1 px-2 align-middle text-xs text-white dark:border-purple-500 dark:bg-purple-700/75',
+        !href ? 'select-none cursor-not-allowed opacity-50' : 'hover:bg-purple-700/60',
+      )}
+    >
+      {downloadLabel}
+    </waymark-download-button>
+    <slot>
+      {
+        img && (
+          <>
+            <Separator class="my-2 mb-3" />
+            <ResizableImageDialog client:idle>
+              <Image src={img} alt="场地标点" class="w-full object-contain object-left-top" />
+            </ResizableImageDialog>
+          </>
+        )
+      }
+    </slot>
+  </AreaBox>
+
+  <AreaBox class="flex-1">
     <div class="shrink space-y-4">
       <T variant="yellow" text="使用说明" />
       <p class="font-extrabold">0. 请在游戏更新后，相应副本开启后再操作，否则可能会炸掉游戏</p>
@@ -229,15 +235,6 @@ const { href, img }: Props = Astro.props
                   }
 
                   /* 暗色模式样式 */
-                  :host-context(.dark) .download-btn {
-                      border-color: #7e22ce;
-                      background-color: rgba(126, 34, 206, 0.75);
-                  }
-
-                  :host-context(.dark) .download-btn:hover:not(:disabled) {
-                      background-color: rgba(109, 40, 217, 0.9);
-                  }
-
                   :host-context(.dark) .confirm-dialog {
                       background: #1f2937;
                       border-color: #374151;

--- a/src/pages/07/m5s/index.astro
+++ b/src/pages/07/m5s/index.astro
@@ -67,7 +67,7 @@ const videoLink = duty.bilibili ?? undefined
     </AreaBox>
   </CollapsibleBox>
   <CollapsibleBox id="waymark" client:idle class="w-full">
-    <WaymarkBox href="/waymarks/07/AacCruiserweight/UISAVE.DAT" img={WaymarkImage} />
+    <WaymarkBox href="/waymarks/07/AacCruiserweight/UISAVE.DAT" img={WaymarkImage} downloadLabel="下载5~8层标点文件" />
     <Fragment slot="header">
       <span>场地标点</span>
     </Fragment>

--- a/src/pages/07/m6s/index.astro
+++ b/src/pages/07/m6s/index.astro
@@ -77,7 +77,7 @@ const videoLink = ''
     </AreaBox>
   </CollapsibleBox>
   <CollapsibleBox id="waymark" client:idle class="w-full">
-    <WaymarkBox href="/waymarks/07/AacCruiserweight/UISAVE.DAT" img={WaymarkImage} />
+    <WaymarkBox href="/waymarks/07/AacCruiserweight/UISAVE.DAT" img={WaymarkImage} downloadLabel="下载5~8层标点文件" />
     <Fragment slot="header">
       <span>场地标点</span>
     </Fragment>

--- a/src/pages/07/m7s/index.astro
+++ b/src/pages/07/m7s/index.astro
@@ -68,7 +68,7 @@ const videoLink = ''
     </AreaBox>
   </CollapsibleBox>
   <CollapsibleBox id="waymark" client:idle class="w-full">
-    <WaymarkBox href="/waymarks/07/AacCruiserweight/UISAVE.DAT">
+    <WaymarkBox href="/waymarks/07/AacCruiserweight/UISAVE.DAT" downloadLabel="下载5~8层标点文件">
       <Separator class="my-2 mb-3" />
       <strong class="text-sm opacity-60">P2场地</strong>
       <ResizableImageDialog client:idle>

--- a/src/pages/07/m8s1/index.astro
+++ b/src/pages/07/m8s1/index.astro
@@ -80,7 +80,7 @@ const videoLink = ''
     </AreaBox>
   </CollapsibleBox>
   <CollapsibleBox id="waymark" client:idle class="w-full">
-    <WaymarkBox href="/waymarks/07/AacCruiserweight/UISAVE.DAT" img={WaymarkImage} />
+    <WaymarkBox href="/waymarks/07/AacCruiserweight/UISAVE.DAT" img={WaymarkImage} downloadLabel="下载5~8层标点文件" />
     <Fragment slot="header">
       <span>场地标点</span>
     </Fragment>

--- a/src/pages/07/m8s2/index.astro
+++ b/src/pages/07/m8s2/index.astro
@@ -79,7 +79,7 @@ const videoLink = ''
     </AreaBox>
   </CollapsibleBox>
   <CollapsibleBox id="waymark" client:idle class="w-full">
-    <WaymarkBox href="/waymarks/07/AacCruiserweight/UISAVE.DAT" img={WaymarkImage} />
+    <WaymarkBox href="/waymarks/07/AacCruiserweight/UISAVE.DAT" img={WaymarkImage} downloadLabel="下载5~8层标点文件" />
     <Fragment slot="header">
       <span>场地标点</span>
     </Fragment>

--- a/src/pages/07/zelenia/index.astro
+++ b/src/pages/07/zelenia/index.astro
@@ -10,6 +10,7 @@ import CollapsibleBox from '@/components/CollapsibleBox.vue'
 import AreaBox from '@/components/AreaBox.astro'
 
 import ResizableImageDialog from '@/components/ResizableImageDialog.vue'
+import WaymarkBox from '@/components/WaymarkBox.astro'
 import Macro from '@/components/Macro.astro'
 import ReferenceItem from '@/components/ReferenceItem.astro'
 import Thanks from '@/components/thanks/Thanks.astro'
@@ -33,6 +34,7 @@ const navList = [
   { label: '鸣谢', id: 'thanks' },
 ]
 const videoLink = 'https://www.bilibili.com/video/BV1n2NYzZEbR/'
+const waymarkLink = ''
 ---
 
 <DutyHomeLayout dutyId={dutyId} navList={navList}>
@@ -72,20 +74,9 @@ const videoLink = 'https://www.bilibili.com/video/BV1n2NYzZEbR/'
     </AreaBox>
   </CollapsibleBox>
   <CollapsibleBox id="waymark" client:idle class="w-full">
-    <div class="w-sm">
-      <AreaBox>
-        <button
-          class="!disabled:hover:bg-purple-700/60 inline-flex w-max cursor-pointer items-center justify-between gap-1 rounded-lg border border-purple-400 bg-purple-500 p-1 px-2 align-middle text-xs text-white disabled:cursor-not-allowed disabled:opacity-50 dark:border-purple-500 dark:bg-purple-700/75"
-          disabled="true"
-        >
-          下载标点文件
-        </button>
-        <Separator class="my-2 mb-3" />
-        <ResizableImageDialog client:idle>
-          <Image src={WaymarkImage} alt="泽莲尼娅歼殛战 场地标点" class="w-full object-contain object-left-top" />
-        </ResizableImageDialog>
-      </AreaBox>
-    </div>
+    <AreaBox>
+      <WaymarkBox href={waymarkLink} img={WaymarkImage} />
+    </AreaBox>
     <Fragment slot="header">
       <span>场地标点</span>
     </Fragment>


### PR DESCRIPTION
1. 调整5~8层下载标点文件文案
2. 修复 Dark Mode 下，下载按钮样式错误的问题